### PR TITLE
fix: reduce Better Auth signup CPU usage

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,6 +5,10 @@ import { openAPI } from 'better-auth/plugins';
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from '../src/db/schema';
 import type { Bindings } from '../src/types';
+import {
+  hashPassword as hashLegacyPassword,
+  verifyPassword as verifyLegacyPassword,
+} from '../src/utils/crypto';
 
 function getAuthSecret(env?: Bindings) {
   const secret = env?.BETTER_AUTH_SECRET?.trim();
@@ -29,6 +33,27 @@ function getCookieAttributes(baseURL: string) {
   };
 }
 
+async function hashWorkerPassword(password: string) {
+  const { salt, hash } = await hashLegacyPassword(password);
+  return `${salt}:${hash}`;
+}
+
+async function verifyWorkerPassword({
+  hash,
+  password,
+}: {
+  hash: string;
+  password: string;
+}) {
+  const [salt, derivedHash] = hash.split(':');
+
+  if (!salt || !derivedHash) {
+    return false;
+  }
+
+  return verifyLegacyPassword(password, salt, derivedHash);
+}
+
 export function createAuth(database: Bindings['DB'], env?: Bindings) {
   const db = drizzle(database, { schema });
   const baseURL = env?.DOMAIN || 'http://localhost:8787';
@@ -45,6 +70,10 @@ export function createAuth(database: Bindings['DB'], env?: Bindings) {
     baseURL,
     emailAndPassword: {
       enabled: true,
+      password: {
+        hash: hashWorkerPassword,
+        verify: verifyWorkerPassword,
+      },
     },
     user: {
       modelName: 'users',

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -113,30 +113,25 @@ const auth = factory
       const displayName = name || email.split('@')[0] || 'User';
 
       try {
-        const result = await betterAuth.api.signUpEmail({
-          body: { email, password, name: displayName },
-          headers: c.req.raw.headers,
-        });
-
-        const signInResponse = await betterAuth.handler(
-          new Request(new URL('/api/auth/sign-in/email', c.req.url), {
+        const signUpResponse = await betterAuth.handler(
+          new Request(new URL('/api/auth/sign-up/email', c.req.url), {
             method: 'POST',
             headers: new Headers({
               'content-type': 'application/json',
               origin: c.req.header('origin') || new URL(c.req.url).origin,
             }),
-            body: JSON.stringify({ email, password }),
+            body: JSON.stringify({ email, password, name: displayName }),
           }),
         );
 
-        const signInBody = await readAuthResponseBody(signInResponse);
+        const signUpBody = await readAuthResponseBody(signUpResponse);
 
-        if (!signInResponse.ok) {
+        if (!signUpResponse.ok) {
           return jsonResponse(
-            Object.keys(signInBody).length > 0
-              ? signInBody
-              : { error: 'User created but session could not be established' },
-            signInResponse.status,
+            Object.keys(signUpBody).length > 0
+              ? signUpBody
+              : { error: 'Failed to create user' },
+            signUpResponse.status,
           );
         }
 
@@ -144,12 +139,12 @@ const auth = factory
           {
             success: true,
             message: 'User created successfully',
-            user: result.user,
+            user: signUpBody.user,
           },
           200,
         );
 
-        const setCookie = signInResponse.headers.get('set-cookie');
+        const setCookie = signUpResponse.headers.get('set-cookie');
         if (setCookie) {
           response.headers.set('set-cookie', setCookie);
         }

--- a/test/mocks/auth.ts
+++ b/test/mocks/auth.ts
@@ -34,6 +34,26 @@ const signUpEmail = vi.fn(async ({ body }: { body: Record<string, unknown> }) =>
 const handler = vi.fn(async (request: Request) => {
   const url = new URL(request.url);
 
+  if (url.pathname.endsWith('/sign-up/email')) {
+    return new Response(
+      JSON.stringify({
+        token: 'mock-session-token',
+        user: {
+          id: 'user_123',
+          email: 'test@example.com',
+          name: 'Test User',
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'set-cookie': 'better-auth.session_token=mock-session-token; HttpOnly; Path=/; SameSite=None; Secure',
+        },
+      },
+    );
+  }
+
   if (url.pathname.endsWith('/sign-in/email')) {
     return new Response(
       JSON.stringify({

--- a/test/routes/auth.spec.ts
+++ b/test/routes/auth.spec.ts
@@ -39,7 +39,11 @@ describe('Auth Routes', () => {
 
     const json = (await res.json()) as { message: string };
     expect(json.message).toMatch(/success/i);
-    expect(mockBetterAuth.signUpEmail).toHaveBeenCalled();
+    expect(mockBetterAuth.handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost/api/auth/sign-up/email',
+      }),
+    );
 
     const setCookieHeader = res.headers.get('set-cookie');
     expect(setCookieHeader).toContain('better-auth.session_token=mock-session-token');


### PR DESCRIPTION
## Summary
- avoid double work during signup by calling Better Auth's sign-up endpoint directly instead of signing up and then immediately signing in again
- configure Better Auth email/password hashing to use the existing Web Crypto PBKDF2 helper, which is more Worker-friendly than the default scrypt path
- update auth mocks/tests to cover the direct sign-up flow and session cookie behavior

## Testing
- pnpm vitest run test/routes/auth.spec.ts test/routes/passKeyAuth.spec.ts test/routes/shoppingCart.spec.ts test/routes/users.spec.ts

## Context
This addresses the Cloudflare 1102 resource limit failure seen on the signup endpoint.