### PR TITLE
Fix inconsistent auth coverage across API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ The API now uses Better Auth for session-based authentication.
 - Compatibility routes remain available at `/auth/signup`, `/auth/signin`, and `/auth/signout`.
 - Native Better Auth routes are mounted under `/api/auth/*`.
 
+### Route auth policy
+
+The API uses the following route protection rules:
+
+- **Public read routes**: product browsing and read-only catalog endpoints such as `GET /products`, `GET /products/search`, `GET /product/:id`, `GET /categories`, and public printer metadata endpoints.
+- **Authenticated user routes**: profile endpoints, saved upload endpoints, shipping/payment-intent helpers tied to a signed-in user, and product/category mutation routes such as `POST /add-product`, `POST /v2/add-product`, `PUT /update-product`, `DELETE /delete-product/:id`, and `POST /add-category`.
+- **Ownership checks**: authenticated upload lookup endpoints also enforce that a user can only access their own uploaded files.
+
+When adding new routes, apply `authMiddleware` directly on the protected route or protected route group before the handler declaration. Do not rely on later middleware registration order.
+
 ### Native Better Auth reference docs
 
 When the local dev server is running, Better Auth exposes an interactive native API reference at:

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import product from './routes/product';
 import shoppingCart from './routes/shoppingCart';
 import userRouter from './routes/users';
 import webhookRoutes from './routes/webhooks';
-import { authMiddleware } from './utils/authMiddleware';
 
 const app = factory
   .createApp()
@@ -36,7 +35,6 @@ const app = factory
     createAuth(c.env.DB, c.env).handler(c.req.raw),
   )
   .route('/auth', auth)
-  .use('/product', authMiddleware)
   .route('/', product)
   .route('/', userRouter)
   .route('/', printer)

--- a/src/routes/printer.ts
+++ b/src/routes/printer.ts
@@ -720,7 +720,7 @@ const printer = factory
       );
     }
   })
-  .post('/v2/upload', describeRoute(v2UploadDoc), async (c: Context) => {
+  .post('/v2/upload', authMiddleware, describeRoute(v2UploadDoc), async (c: Context) => {
     try {
       const body = await c.req.parseBody();
 
@@ -1105,10 +1105,9 @@ const printer = factory
       );
     }
   })
-  .use('/v2/upload', authMiddleware)
-  .use('/v2/uploads/:id', authMiddleware)
   .get(
     '/v2/uploads/:id',
+    authMiddleware,
     describeRoute(getUploadedFileDoc),
     async (c: Context) => {
       try {
@@ -1117,7 +1116,6 @@ const printer = factory
 
         // Check if ID is numeric or UUID
         const isNumeric = /^\d+$/.test(id);
-
         const result = isNumeric
           ? await c.var.db
               .select()
@@ -1172,9 +1170,9 @@ const printer = factory
       }
     },
   )
-  .use('/v2/uploads', authMiddleware)
   .get(
     '/v2/uploads',
+    authMiddleware,
     describeRoute(getUploadedFilesDoc),
     async (c: Context) => {
       try {

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -207,7 +207,6 @@ const product = factory
       }
     },
   )
-  .use('/products/search', authMiddleware)
   .get(
     '/products/search',
     describeRoute({
@@ -368,10 +367,9 @@ const product = factory
       }
     },
   )
-  .use('/add-product', authMiddleware)
-  .use('/update-product', authMiddleware)
   .post(
     '/add-product',
+    authMiddleware,
     describeRoute({
       description: 'Add a new product',
       tags: ['Products'],
@@ -407,7 +405,7 @@ const product = factory
       const stripe = new Stripe(c.env.STRIPE_SECRET_KEY, {
         telemetry: false,
       });
-      const user = c.get('jwtPayload') as { id: number; email: string };
+      const user = c.get('jwtPayload') as { id: string; email: string } | undefined;
       if (!user) return c.json({ error: 'Unauthorized' }, 401);
       const data = await c.req.valid('json');
       const { categoryIds, categoryId, imageGallery, ...rest } = data;
@@ -528,9 +526,9 @@ const product = factory
       }
     },
   )
-  .use('/v2/add-product', authMiddleware)
   .post(
     '/v2/add-product',
+    authMiddleware,
     describeRoute({
       description: 'Add a new product using Slant3D V2 API',
       tags: ['Products'],
@@ -603,7 +601,7 @@ const product = factory
         const stripe = new Stripe(c.env.STRIPE_SECRET_KEY, {
           telemetry: false,
         });
-        const user = c.get('jwtPayload') as { id: number; email: string };
+        const user = c.get('jwtPayload') as { id: string; email: string } | undefined;
         if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
         const data = await c.req.valid('json');
@@ -996,6 +994,7 @@ const product = factory
   )
   .put(
     '/update-product',
+    authMiddleware,
     describeRoute({
       description: 'Update an existing product',
       tags: ['Products'],
@@ -1096,7 +1095,13 @@ const product = factory
                 type: 'object',
                 properties: {
                   error: { type: 'string' },
-                  details: { type: 'array' },
+                  details: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      additionalProperties: true,
+                    },
+                  },
                 },
               },
             },
@@ -1288,6 +1293,7 @@ const product = factory
   )
   .post(
     '/add-category',
+    authMiddleware,
     describeRoute({
       summary: 'Add a new product category',
       description: 'Creates a new category and returns the created record.',

--- a/test/routes/printerUploadV2.spec.ts
+++ b/test/routes/printerUploadV2.spec.ts
@@ -7,6 +7,10 @@ import { mockEnv } from '../mocks/env';
 const MOCK_STL_CONTENT =
   'solid test\nfacet normal 0 0 0\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\nendsolid';
 
+const authHeaders = {
+  Cookie: 'better-auth.session_token=mock-session-token',
+};
+
 describe('Printer V2 Upload Routes', () => {
   describe('POST /v2/upload', () => {
     let env: ReturnType<typeof mockEnv>;
@@ -14,6 +18,24 @@ describe('Printer V2 Upload Routes', () => {
     beforeEach(() => {
       env = mockEnv();
       vi.clearAllMocks();
+    });
+
+    test('should return 401 when not authenticated', async () => {
+      const file = new File([MOCK_STL_CONTENT], 'test-model.stl', {
+        type: 'model/stl',
+      });
+
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const request = new Request('http://localhost/v2/upload', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await app.fetch(request, env);
+
+      expect(response.status).toBe(401);
     });
 
     test('should successfully upload and register STL file', async () => {
@@ -107,6 +129,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -137,6 +160,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -238,6 +262,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -254,6 +279,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -290,6 +316,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -340,6 +367,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -380,6 +408,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -415,6 +444,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -438,6 +468,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 
@@ -532,6 +563,7 @@ describe('Printer V2 Upload Routes', () => {
 
       const request = new Request('http://localhost/v2/upload', {
         method: 'POST',
+        headers: authHeaders,
         body: formData,
       });
 

--- a/test/routes/product.spec.ts
+++ b/test/routes/product.spec.ts
@@ -47,9 +47,6 @@ describe('Product Routes', () => {
 
     const request = new Request('http://localhost/products', {
       method: 'GET',
-      headers: {
-        Cookie: fakeSignedCookie,
-      },
     });
 
     const res = await app.fetch(request, mockEnv());
@@ -71,9 +68,6 @@ describe('Product Routes', () => {
 
     const request = new Request('http://localhost/product/1', {
       method: 'GET',
-      headers: {
-        Cookie: fakeSignedCookie,
-      },
     });
 
     const res = await app.fetch(request, mockEnv());
@@ -94,9 +88,6 @@ describe('Product Routes', () => {
 
     const request = new Request('http://localhost/product/999', {
       method: 'GET',
-      headers: {
-        Cookie: fakeSignedCookie,
-      },
     });
 
     const res = await app.fetch(request, mockEnv());
@@ -104,6 +95,40 @@ describe('Product Routes', () => {
     expect(res.status).toBe(404);
     const data = (await res.json()) as { error: string };
     expect(data.error).toMatch(/not found/i);
+  });
+
+  test('GET /products/search is public', async () => {
+    const request = new Request('http://localhost/products/search?q=a', {
+      method: 'GET',
+    });
+
+    const res = await app.fetch(request, mockEnv());
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('at least 2 characters');
+  });
+
+  test('POST /add-product returns 401 when not authenticated', async () => {
+    const request = new Request('http://localhost/add-product', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'New Product',
+        description: 'desc',
+        stl: 'url/to.stl',
+        price: 15,
+        image: 'url/to/image.jpg',
+        filamentType: 'PLA',
+        color: '#ffffff',
+      }),
+    });
+
+    const res = await app.fetch(request, mockEnv());
+
+    expect(res.status).toBe(401);
   });
 
   test('POST /add-product adds a product without categories', async () => {
@@ -283,6 +308,30 @@ describe('Product Routes', () => {
     expect(data).toHaveProperty('error');
   });
 
+  test('PUT /update-product returns 401 when not authenticated', async () => {
+    const request = new Request('http://localhost/update-product', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1,
+        name: 'Updated Product',
+        description: 'Updated desc',
+        price: 20,
+        image: 'url/to/image.jpg',
+        filamentType: 'PLA',
+        color: '#000000',
+        stl: 'url/to/updated.stl',
+        skuNumber: 'SKU123',
+      }),
+    });
+
+    const res = await app.fetch(request, mockEnv());
+
+    expect(res.status).toBe(401);
+  });
+
   test('DELETE /delete-product/:id deletes a product', async () => {
     mockDelete.mockResolvedValueOnce({ changes: 1 });
 
@@ -300,5 +349,29 @@ describe('Product Routes', () => {
     expect(res.status).toBe(200);
     const data = (await res.json()) as { success: boolean };
     expect(data.success).toBe(true);
+  });
+
+  test('DELETE /delete-product/:id returns 401 when not authenticated', async () => {
+    const request = new Request('http://localhost/delete-product/1', {
+      method: 'DELETE',
+    });
+
+    const res = await app.fetch(request, mockEnv());
+
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /add-category returns 401 when not authenticated', async () => {
+    const request = new Request('http://localhost/add-category', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ categoryName: 'Accessories' }),
+    });
+
+    const res = await app.fetch(request, mockEnv());
+
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- make protected product mutations use explicit route-level auth instead of relying on the top-level product prefix
- protect printer v2 upload and uploads endpoints without depending on middleware declaration order
- document the route auth policy and add regression tests for public and protected endpoints

## Testing
- pnpm vitest run test/routes/product.spec.ts test/routes/printerUploadV2.spec.ts test/routes/shoppingCart.spec.ts test/routes/users.spec.ts

Closes #83