### PR TITLE
finally able to order using the v2 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ This project uses Drizzle ORM for database schema management and migrations. Bel
 When you make changes to the database schema in `src/db/schema.ts`, generate a migration file:
 
 ```bash
-npx drizzle-kit generate
+pnpm run db:generate
 ```
+
+Equivalent raw command: `npx drizzle-kit generate`
 
 This will:
 - Create a new migration file in `drizzle/migrations/`
@@ -138,10 +140,10 @@ To apply migrations to your local development database:
 
 ```bash
 # Option 1: Apply all pending migrations
-npx drizzle-kit migrate
+pnpm run db:migrate:local
 
 # Option 2: Push schema changes directly (development only)
-npx drizzle-kit push
+pnpm run db:push:local
 ```
 
 **Note**: `drizzle-kit push` is faster for development but doesn't create migration files. Use `generate` + `migrate` for production-ready changes.
@@ -158,6 +160,30 @@ pnpm run dev
 #### Prerequisites
 - Ensure you're authenticated with Cloudflare: `npx wrangler auth login`
 - Have the correct database name configured in `wrangler.toml`
+- Ensure the target D1 binding points at `migrations_dir = "./drizzle/migrations"`
+
+#### Recommended remote workflow
+
+Use Drizzle to generate reviewed SQL migration files locally, then let Wrangler apply any pending migrations remotely in order.
+
+```bash
+# 1. Generate the next migration locally
+pnpm run db:generate
+
+# 2. Test locally
+pnpm run db:migrate:local
+
+# 3. Apply all pending migrations to production D1
+pnpm run db:migrate:remote
+```
+
+Equivalent raw remote command:
+
+```bash
+npx wrangler d1 migrations apply ecommerce --remote
+```
+
+Wrangler tracks applied migrations for the configured database, so re-running the command is safe when the remote database is already up to date.
 
 #### Cloudflare Dashboard workflow
 
@@ -180,29 +206,7 @@ For the Better Auth organization-role migration in this repository, make sure `d
 - `invitation`
 - `session.active_organization_id`
 
-#### 1. Apply Individual Migration Files
-For each migration file that needs to be applied to the remote database:
-
-```bash
-npx wrangler d1 execute DATABASE_NAME --remote --file=drizzle/migrations/MIGRATION_FILE.sql
-```
-
-**Example**:
-```bash
-npx wrangler d1 execute ecommerce --remote --file=drizzle/migrations/0002_uneven_glorian.sql
-```
-
-#### 2. Apply Multiple Migrations
-If you have multiple migration files to apply, run them in order:
-
-```bash
-# Apply migrations in chronological order
-npx wrangler d1 execute ecommerce --remote --file=drizzle/migrations/0001_initial.sql
-npx wrangler d1 execute ecommerce --remote --file=drizzle/migrations/0002_add_column.sql
-npx wrangler d1 execute ecommerce --remote --file=drizzle/migrations/0003_update_indexes.sql
-```
-
-#### 3. Execute Custom SQL Scripts
+#### Fallback: Execute Custom SQL Scripts
 For data cleanup or custom operations:
 
 ```bash
@@ -216,7 +220,9 @@ npx wrangler d1 execute ecommerce --remote --file=cleanup.sql
 rm cleanup.sql
 ```
 
-#### 4. Verify Remote Changes
+Use `wrangler d1 execute --file=...` for exceptional one-off fixes or recovery steps, not as the standard migration path.
+
+#### Verify Remote Changes
 Check that your migrations were applied successfully:
 
 ```bash
@@ -227,7 +233,7 @@ npx wrangler d1 execute ecommerce --remote --command="SELECT sql FROM sqlite_mas
 npx wrangler d1 execute ecommerce --remote --command="PRAGMA table_info(products);"
 ```
 
-#### 5. Deploy Updated Code
+#### Deploy Updated Code
 After applying database migrations, deploy your updated application:
 
 ```bash
@@ -238,20 +244,20 @@ pnpm run deploy
 
 #### Development Workflow
 1. **Make schema changes** in `src/db/schema.ts`
-2. **Generate migration** with `npx drizzle-kit generate`
-3. **Test locally** with `npx drizzle-kit migrate` or `npx drizzle-kit push`
+2. **Generate migration** with `pnpm run db:generate`
+3. **Test locally** with `pnpm run db:migrate:local` or `pnpm run db:push:local`
 4. **Verify functionality** by running `pnpm run dev`
 5. **Commit changes** including both schema and migration files
 
 #### Production Deployment
 1. **Review migration files** before applying to production
 2. **Backup database** (if applicable) before running migrations
-3. **Apply migrations** to remote D1 database using `wrangler d1 execute`
+3. **Apply migrations** to remote D1 database using `pnpm run db:migrate:remote`
 4. **Deploy application** with `pnpm run deploy`
 5. **Test endpoints** to ensure everything works correctly
 
 #### Important Notes
-- **Order matters**: Apply migrations in chronological order (0001, 0002, 0003, etc.)
+- **Order matters**: Wrangler applies pending migrations in order from `drizzle/migrations/`
 - **No rollbacks**: D1 doesn't support automatic rollbacks, plan migrations carefully
 - **Downtime**: Remote migrations may cause brief downtime during execution
 - **Testing**: Always test migrations locally before applying to production

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   schema: './src/db/schema.ts',
   out: './drizzle/migrations',
   dbCredentials: {
-    url: './.wrangler/state/v3/d1/miniflare-D1DatabaseObject/8ba66c13aba5f68777f0257c566d84c7868991eb41ee8d2ea3d9bc80c950bdc4.sqlite',
+    url: './.wrangler/state/v3/d1/miniflare-D1DatabaseObject/07ea714d68aae2552dfa4e8d9a26eec21fff446097f8bebf5021b7eebda92aa7.sqlite',
   },
 });

--- a/drizzle/migrations/0004_ancient_triathlon.sql
+++ b/drizzle/migrations/0004_ancient_triathlon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `cart` ADD `user_id` text REFERENCES users(id);--> statement-breakpoint
+ALTER TABLE `cart` ADD `filament_id` text DEFAULT '76fe1f79-3f1e-43e4-b8f4-61159de5b93c';

--- a/drizzle/migrations/meta/0004_snapshot.json
+++ b/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1452 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "05b11fad-7b72-4ba8-a8d9-c5bf81aeace0",
+  "prevId": "21df51a5-db92-4a1e-8acc-00071f61a470",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_users_id_fk": {
+          "name": "account_user_id_users_id_fk",
+          "tableFrom": "account",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cart": {
+      "name": "cart",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku_number": {
+          "name": "sku_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "filament_type": {
+          "name": "filament_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filament_id": {
+          "name": "filament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'76fe1f79-3f1e-43e4-b8f4-61159de5b93c'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_user_id_users_id_fk": {
+          "name": "cart_user_id_users_id_fk",
+          "tableFrom": "cart",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "categoryId": {
+          "name": "categoryId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "categoryName": {
+          "name": "categoryName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leads": {
+      "name": "leads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "leads_email_unique": {
+          "name": "leads_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ordersTable": {
+      "name": "ordersTable",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_name": {
+          "name": "ship_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_street_1": {
+          "name": "ship_to_street_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_street_2": {
+          "name": "ship_to_street_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ship_to_city": {
+          "name": "ship_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_state": {
+          "name": "ship_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_zip": {
+          "name": "ship_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ship_to_country_iso": {
+          "name": "ship_to_country_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bill_to_street_1": {
+          "name": "bill_to_street_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bill_to_street_2": {
+          "name": "bill_to_street_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bill_to_country_iso": {
+          "name": "bill_to_country_iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ordersTable_order_number_unique": {
+          "name": "ordersTable_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ordersTable_user_id_users_id_fk": {
+          "name": "ordersTable_user_id_users_id_fk",
+          "tableFrom": "ordersTable",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_users_id_fk": {
+          "name": "passkey_user_id_users_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "image_gallery": {
+          "name": "image_gallery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stl": {
+          "name": "stl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "filament_type": {
+          "name": "filament_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PLA'"
+        },
+        "sku_number": {
+          "name": "sku_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_file_service_id": {
+          "name": "public_file_service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_categoryId_category_categoryId_fk": {
+          "name": "products_categoryId_category_categoryId_fk",
+          "tableFrom": "products",
+          "tableTo": "category",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "categoryId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products_to_categories": {
+      "name": "products_to_categories",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_to_categories_product_id_products_id_fk": {
+          "name": "products_to_categories_product_id_products_id_fk",
+          "tableFrom": "products_to_categories",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "products_to_categories_category_id_category_categoryId_fk": {
+          "name": "products_to_categories_category_id_category_categoryId_fk",
+          "tableFrom": "products_to_categories",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "categoryId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "products_to_categories_product_id_category_id_pk": {
+          "columns": [
+            "product_id",
+            "category_id"
+          ],
+          "name": "products_to_categories_product_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_users_id_fk": {
+          "name": "session_user_id_users_id_fk",
+          "tableFrom": "session",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploaded_files": {
+      "name": "uploaded_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_file_service_id": {
+          "name": "public_file_service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_x": {
+          "name": "dimension_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimension_y": {
+          "name": "dimension_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimension_z": {
+          "name": "dimension_z",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "surface_area": {
+          "name": "surface_area",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_filament_id": {
+          "name": "default_filament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'76fe1f79-3f1e-43e4-b8f4-61159de5b93c'"
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_quantity": {
+          "name": "estimated_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uploaded_files_public_file_service_id_unique": {
+          "name": "uploaded_files_public_file_service_id_unique",
+          "columns": [
+            "public_file_service_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_users_id_fk": {
+          "name": "uploaded_files_user_id_users_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781170130000,
       "tag": "0003_cart_filament_id",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781248342840,
+      "tag": "0004_ancient_triathlon",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/relations.ts
+++ b/drizzle/migrations/relations.ts
@@ -1,67 +1,106 @@
-import { relations } from 'drizzle-orm/relations';
-import {
-  authenticators,
-  category,
-  ordersTable,
-  products,
-  productsToCategories,
-  users,
-  webauthnChallenges,
-} from './schema';
+import { relations } from "drizzle-orm/relations";
+import { users, account, ordersTable, passkey, category, products, session, uploadedFiles, invitation, organization, member, productsToCategories, cart } from "./schema";
 
-export const authenticatorsRelations = relations(authenticators, ({ one }) => ({
-  user: one(users, {
-    fields: [authenticators.userId],
-    references: [users.id],
-  }),
+export const accountRelations = relations(account, ({one}) => ({
+	user: one(users, {
+		fields: [account.userId],
+		references: [users.id]
+	}),
 }));
 
-export const usersRelations = relations(users, ({ many }) => ({
-  authenticators: many(authenticators),
-  ordersTables: many(ordersTable),
-  webauthnChallenges: many(webauthnChallenges),
+export const usersRelations = relations(users, ({many}) => ({
+	accounts: many(account),
+	ordersTables: many(ordersTable),
+	passkeys: many(passkey),
+	sessions: many(session),
+	uploadedFiles: many(uploadedFiles),
+	invitations: many(invitation),
+	members: many(member),
+	carts: many(cart),
 }));
 
-export const ordersTableRelations = relations(ordersTable, ({ one }) => ({
-  user: one(users, {
-    fields: [ordersTable.userId],
-    references: [users.id],
-  }),
+export const ordersTableRelations = relations(ordersTable, ({one}) => ({
+	user: one(users, {
+		fields: [ordersTable.userId],
+		references: [users.id]
+	}),
 }));
 
-export const webauthnChallengesRelations = relations(
-  webauthnChallenges,
-  ({ one }) => ({
-    user: one(users, {
-      fields: [webauthnChallenges.userId],
-      references: [users.id],
-    }),
-  }),
-);
-
-export const productsRelations = relations(products, ({ one, many }) => ({
-  category: one(category, {
-    fields: [products.categoryId],
-    references: [category.categoryId],
-  }),
-  productsToCategories: many(productsToCategories),
+export const passkeyRelations = relations(passkey, ({one}) => ({
+	user: one(users, {
+		fields: [passkey.userId],
+		references: [users.id]
+	}),
 }));
 
-export const categoryRelations = relations(category, ({ many }) => ({
-  products: many(products),
-  productsToCategories: many(productsToCategories),
+export const productsRelations = relations(products, ({one, many}) => ({
+	category: one(category, {
+		fields: [products.categoryId],
+		references: [category.categoryId]
+	}),
+	productsToCategories: many(productsToCategories),
 }));
 
-export const productsToCategoriesRelations = relations(
-  productsToCategories,
-  ({ one }) => ({
-    category: one(category, {
-      fields: [productsToCategories.categoryId],
-      references: [category.categoryId],
-    }),
-    product: one(products, {
-      fields: [productsToCategories.productId],
-      references: [products.id],
-    }),
-  }),
-);
+export const categoryRelations = relations(category, ({many}) => ({
+	products: many(products),
+	productsToCategories: many(productsToCategories),
+}));
+
+export const sessionRelations = relations(session, ({one}) => ({
+	user: one(users, {
+		fields: [session.userId],
+		references: [users.id]
+	}),
+}));
+
+export const uploadedFilesRelations = relations(uploadedFiles, ({one}) => ({
+	user: one(users, {
+		fields: [uploadedFiles.userId],
+		references: [users.id]
+	}),
+}));
+
+export const invitationRelations = relations(invitation, ({one}) => ({
+	user: one(users, {
+		fields: [invitation.inviterId],
+		references: [users.id]
+	}),
+	organization: one(organization, {
+		fields: [invitation.organizationId],
+		references: [organization.id]
+	}),
+}));
+
+export const organizationRelations = relations(organization, ({many}) => ({
+	invitations: many(invitation),
+	members: many(member),
+}));
+
+export const memberRelations = relations(member, ({one}) => ({
+	user: one(users, {
+		fields: [member.userId],
+		references: [users.id]
+	}),
+	organization: one(organization, {
+		fields: [member.organizationId],
+		references: [organization.id]
+	}),
+}));
+
+export const productsToCategoriesRelations = relations(productsToCategories, ({one}) => ({
+	category: one(category, {
+		fields: [productsToCategories.categoryId],
+		references: [category.categoryId]
+	}),
+	product: one(products, {
+		fields: [productsToCategories.productId],
+		references: [products.id]
+	}),
+}));
+
+export const cartRelations = relations(cart, ({one}) => ({
+	user: one(users, {
+		fields: [cart.userId],
+		references: [users.id]
+	}),
+}));

--- a/drizzle/migrations/schema.ts
+++ b/drizzle/migrations/schema.ts
@@ -1,160 +1,214 @@
-import { sql } from 'drizzle-orm';
-import {
-  AnySQLiteColumn,
-  blob,
-  foreignKey,
-  integer,
-  primaryKey,
-  real,
-  sqliteTable,
-  text,
-  uniqueIndex,
-} from 'drizzle-orm/sqlite-core';
+import { sqliteTable, AnySQLiteColumn, foreignKey, text, integer, uniqueIndex, real, primaryKey } from "drizzle-orm/sqlite-core"
+  import { sql } from "drizzle-orm"
 
-export const authenticators = sqliteTable(
-  'authenticators',
-  {
-    id: integer().primaryKey().notNull(),
-    userId: integer('user_id')
-      .notNull()
-      .references(() => users.id, { onDelete: 'cascade' }),
-    credentialId: text('credential_id').notNull(),
-    credentialPublicKey: blob('credential_public_key').notNull(),
-    counter: integer().default(0).notNull(),
-  },
-  table => [
-    uniqueIndex('authenticators_user_credential_unique').on(
-      table.userId,
-      table.credentialId,
-    ),
-  ],
-);
-
-export const leads = sqliteTable(
-  'leads',
-  {
-    id: integer().primaryKey().notNull(),
-    email: text(),
-    name: text().notNull(),
-    status: text(),
-    confirmedAt: integer('confirmed_at'),
-    createdAt: integer('created_at').notNull(),
-    updatedAt: integer('updated_at'),
-  },
-  table => [uniqueIndex('leads_email_unique').on(table.email)],
-);
-
-export const ordersTable = sqliteTable(
-  'ordersTable',
-  {
-    id: integer().primaryKey().notNull(),
-    userId: integer('user_id')
-      .notNull()
-      .references(() => users.id, { onDelete: 'cascade' }),
-    orderNumber: text('order_number').notNull(),
-    filename: text(),
-    fileUrl: text('file_url').notNull(),
-    shipToName: text('ship_to_name').notNull(),
-    shipToStreet1: text('ship_to_street_1').notNull(),
-    shipToStreet2: text('ship_to_street_2'),
-    shipToCity: text('ship_to_city').notNull(),
-    shipToState: text('ship_to_state').notNull(),
-    shipToZip: text('ship_to_zip').notNull(),
-    shipToCountryIso: text('ship_to_country_iso').notNull(),
-    billToStreet1: text('bill_to_street_1'),
-    billToStreet2: text('bill_to_street_2'),
-    billToCity: text('bill_to_city'),
-    billToState: text('bill_to_state'),
-    billToZip: text('bill_to_zip'),
-    billToCountryIso: text('bill_to_country_iso'),
-  },
-  table => [
-    uniqueIndex('ordersTable_order_number_unique').on(table.orderNumber),
-  ],
-);
-
-export const users = sqliteTable(
-  'users',
-  {
-    id: integer().primaryKey().notNull(),
-    email: text().notNull(),
-    passwordHash: text('password_hash').notNull(),
-    salt: text().notNull(),
-    firstName: text('first_name').default('').notNull(),
-    lastName: text('last_name').default('').notNull(),
-    shippingAddress: text('shipping_address').default('').notNull(),
-    billingAddress: text('billing_address').default('').notNull(),
-    city: text().default('').notNull(),
-    state: text().default('').notNull(),
-    zipCode: text('zip_code').default('').notNull(),
-    country: text().default('').notNull(),
-    phone: text().default('').notNull(),
-    role: text().default('user').notNull(),
-  },
-  table => [uniqueIndex('users_email_unique').on(table.email)],
-);
-
-export const webauthnChallenges = sqliteTable('webauthn_challenges', {
-  userId: integer('user_id')
-    .primaryKey()
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  challenge: text().notNull(),
+export const account = sqliteTable("account", {
+	id: text().primaryKey().notNull(),
+	accountId: text("account_id").notNull(),
+	providerId: text("provider_id").notNull(),
+	userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	accessToken: text("access_token"),
+	refreshToken: text("refresh_token"),
+	idToken: text("id_token"),
+	accessTokenExpiresAt: integer("access_token_expires_at"),
+	refreshTokenExpiresAt: integer("refresh_token_expires_at"),
+	scope: text(),
+	password: text(),
+	createdAt: integer("created_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
 });
 
-export const cart = sqliteTable('cart', {
-  id: integer().primaryKey().notNull(),
-  cartId: text('cart_id').notNull(),
-  skuNumber: text('sku_number').notNull(),
-  quantity: integer().default(1).notNull(),
-  color: text().default('#000000'),
-  filamentType: text('filament_type').notNull(),
+export const category = sqliteTable("category", {
+	categoryId: integer().primaryKey({ autoIncrement: true }).notNull(),
+	categoryName: text().notNull(),
 });
 
-export const category = sqliteTable('category', {
-  categoryId: integer().primaryKey({ autoIncrement: true }).notNull(),
-  categoryName: text().notNull(),
+export const leads = sqliteTable("leads", {
+	id: integer().primaryKey().notNull(),
+	email: text(),
+	name: text().notNull(),
+	status: text(),
+	confirmedAt: integer("confirmed_at"),
+	createdAt: integer("created_at").notNull(),
+	updatedAt: integer("updated_at"),
+},
+(table) => [
+	uniqueIndex("leads_email_unique").on(table.email),
+]);
+
+export const ordersTable = sqliteTable("ordersTable", {
+	id: integer().primaryKey().notNull(),
+	userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	orderNumber: text("order_number").notNull(),
+	filename: text(),
+	fileUrl: text("file_url").notNull(),
+	shipToName: text("ship_to_name").notNull(),
+	shipToStreet1: text("ship_to_street_1").notNull(),
+	shipToStreet2: text("ship_to_street_2"),
+	shipToCity: text("ship_to_city").notNull(),
+	shipToState: text("ship_to_state").notNull(),
+	shipToZip: text("ship_to_zip").notNull(),
+	shipToCountryIso: text("ship_to_country_iso").notNull(),
+	billToStreet1: text("bill_to_street_1"),
+	billToStreet2: text("bill_to_street_2"),
+	billToCity: text("bill_to_city"),
+	billToState: text("bill_to_state"),
+	billToZip: text("bill_to_zip"),
+	billToCountryIso: text("bill_to_country_iso"),
+},
+(table) => [
+	uniqueIndex("ordersTable_order_number_unique").on(table.orderNumber),
+]);
+
+export const passkey = sqliteTable("passkey", {
+	id: text().primaryKey().notNull(),
+	name: text(),
+	publicKey: text("public_key").notNull(),
+	userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	credentialId: text("credential_id").notNull(),
+	counter: integer().notNull(),
+	deviceType: text("device_type").notNull(),
+	backedUp: integer("backed_up").notNull(),
+	transports: text(),
+	createdAt: integer("created_at"),
+	aaguid: text(),
 });
 
-export const products = sqliteTable('products', {
-  id: integer().primaryKey({ autoIncrement: true }).notNull(),
-  name: text().notNull(),
-  description: text().notNull(),
-  image: text().default(''),
-  imageGallery: text('image_gallery'),
-  stl: text().notNull(),
-  price: real().notNull(),
-  filamentType: text('filament_type').default('PLA').notNull(),
-  skuNumber: text('sku_number').default(''),
-  color: text().default('#000000'),
-  stripeProductId: text('stripe_product_id'),
-  stripePriceId: text('stripe_price_id'),
-  categoryId: integer().references(() => category.categoryId),
-  publicFileServiceId: text('public_file_service_id'),
+export const products = sqliteTable("products", {
+	id: integer().primaryKey({ autoIncrement: true }).notNull(),
+	name: text().notNull(),
+	description: text().notNull(),
+	image: text().default(""),
+	imageGallery: text("image_gallery"),
+	stl: text().notNull(),
+	price: real().notNull(),
+	filamentType: text("filament_type").default("PLA").notNull(),
+	skuNumber: text("sku_number").default(""),
+	color: text().default("#000000"),
+	stripeProductId: text("stripe_product_id"),
+	stripePriceId: text("stripe_price_id"),
+	publicFileServiceId: text("public_file_service_id"),
+	categoryId: integer().references(() => category.categoryId),
 });
 
-export const productsToCategories = sqliteTable(
-  'products_to_categories',
-  {
-    productId: integer('product_id')
-      .notNull()
-      .references(() => products.id, {
-        onDelete: 'cascade',
-        onUpdate: 'cascade',
-      }),
-    categoryId: integer('category_id')
-      .notNull()
-      .references(() => category.categoryId, {
-        onDelete: 'set null',
-        onUpdate: 'cascade',
-      }),
-    orderIndex: integer('order_index'),
-    createdAt: text('created_at').default('sql`(CURRENT_TIMESTAMP)`').notNull(),
-  },
-  table => [
-    primaryKey({
-      columns: [table.productId, table.categoryId],
-      name: 'products_to_categories_product_id_category_id_pk',
-    }),
-  ],
-);
+export const session = sqliteTable("session", {
+	id: text().primaryKey().notNull(),
+	expiresAt: integer("expires_at").notNull(),
+	token: text().notNull(),
+	createdAt: integer("created_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
+	ipAddress: text("ip_address"),
+	userAgent: text("user_agent"),
+	userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	impersonatedBy: text("impersonated_by"),
+	activeOrganizationId: text("active_organization_id"),
+},
+(table) => [
+	uniqueIndex("session_token_unique").on(table.token),
+]);
+
+export const uploadedFiles = sqliteTable("uploaded_files", {
+	id: integer().primaryKey({ autoIncrement: true }).notNull(),
+	userId: text("user_id").references(() => users.id, { onDelete: "cascade" } ),
+	publicFileServiceId: text("public_file_service_id").notNull(),
+	fileName: text("file_name").notNull(),
+	fileUrl: text("file_url").notNull(),
+	dimensionX: real("dimension_x"),
+	dimensionY: real("dimension_y"),
+	dimensionZ: real("dimension_z"),
+	volume: real(),
+	weight: real(),
+	surfaceArea: real("surface_area"),
+	defaultFilamentId: text("default_filament_id").default("76fe1f79-3f1e-43e4-b8f4-61159de5b93c"),
+	estimatedCost: real("estimated_cost"),
+	estimatedQuantity: integer("estimated_quantity").default(1),
+	createdAt: integer("created_at").default(sql`(unixepoch())`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(unixepoch())`).notNull(),
+},
+(table) => [
+	uniqueIndex("uploaded_files_public_file_service_id_unique").on(table.publicFileServiceId),
+]);
+
+export const users = sqliteTable("users", {
+	id: text().primaryKey().notNull(),
+	name: text().notNull(),
+	email: text().notNull(),
+	emailVerified: integer("email_verified").default(false).notNull(),
+	image: text(),
+	createdAt: integer("created_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`).notNull(),
+	firstName: text("first_name").default("").notNull(),
+	lastName: text("last_name").default("").notNull(),
+	shippingAddress: text("shipping_address").default("").notNull(),
+	billingAddress: text("billing_address").default("").notNull(),
+	city: text().default("").notNull(),
+	state: text().default("").notNull(),
+	zipCode: text("zip_code").default("").notNull(),
+	country: text().default("").notNull(),
+	phone: text().default("").notNull(),
+	role: text().default("user").notNull(),
+},
+(table) => [
+	uniqueIndex("users_email_unique").on(table.email),
+]);
+
+export const verification = sqliteTable("verification", {
+	id: text().primaryKey().notNull(),
+	identifier: text().notNull(),
+	value: text().notNull(),
+	expiresAt: integer("expires_at").notNull(),
+	createdAt: integer("created_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
+	updatedAt: integer("updated_at").default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
+});
+
+export const invitation = sqliteTable("invitation", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull().references(() => organization.id, { onDelete: "cascade" } ),
+	email: text().notNull(),
+	role: text().notNull(),
+	status: text().default("pending").notNull(),
+	inviterId: text("inviter_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	expiresAt: integer("expires_at"),
+	createdAt: integer("created_at").notNull(),
+});
+
+export const member = sqliteTable("member", {
+	id: text().primaryKey().notNull(),
+	organizationId: text("organization_id").notNull().references(() => organization.id, { onDelete: "cascade" } ),
+	userId: text("user_id").notNull().references(() => users.id, { onDelete: "cascade" } ),
+	role: text().default("member").notNull(),
+	createdAt: integer("created_at").notNull(),
+});
+
+export const organization = sqliteTable("organization", {
+	id: text().primaryKey().notNull(),
+	name: text().notNull(),
+	slug: text().notNull(),
+	logo: text(),
+	metadata: text(),
+	createdAt: integer("created_at").notNull(),
+},
+(table) => [
+	uniqueIndex("organization_slug_unique").on(table.slug),
+]);
+
+export const productsToCategories = sqliteTable("products_to_categories", {
+	productId: integer("product_id").notNull().references(() => products.id, { onDelete: "cascade", onUpdate: "cascade" } ),
+	categoryId: integer("category_id").notNull().references(() => category.categoryId, { onDelete: "set null", onUpdate: "cascade" } ),
+	orderIndex: integer("order_index"),
+	createdAt: text("created_at").default("sql`(CURRENT_TIMESTAMP)`").notNull(),
+},
+(table) => [
+	primaryKey({ columns: [table.productId, table.categoryId], name: "products_to_categories_product_id_category_id_pk"})
+]);
+
+export const cart = sqliteTable("cart", {
+	id: integer().primaryKey().notNull(),
+	cartId: text("cart_id").notNull(),
+	userId: text("user_id").references(() => users.id, { onDelete: "set null" } ),
+	skuNumber: text("sku_number").notNull(),
+	quantity: integer().default(1).notNull(),
+	color: text().default("#000000"),
+	filamentType: text("filament_type").notNull(),
+	filamentId: text("filament_id").default("76fe1f79-3f1e-43e4-b8f4-61159de5b93c"),
+});
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate:local": "drizzle-kit migrate",
+    "db:push:local": "drizzle-kit push",
+    "db:migrate:remote": "wrangler d1 migrations apply ecommerce --remote",
     "generate:project-notes": "node --disable-warning=ExperimentalWarning --experimental-default-type=module --experimental-strip-types tools/project-notes/generate-project-notes.ts",
     "validate:project-notes-pr": "node --disable-warning=ExperimentalWarning --experimental-default-type=module --experimental-strip-types tools/project-notes/validate-pr-notes.ts",
     "deploy": "wrangler deploy",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -393,20 +393,34 @@ export const orderSchema = z
   })
   .strict();
 
-export const addProductSchema = z.object({
-  name: z.string(),
-  description: z.string(),
-  stl: z.string(),
-  price: z.number(),
-  filamentType: z.string(),
-  color: z.string(),
-  image: z.string(),
-  imageGallery: z.array(z.string()).min(1).optional(),
-  // Accept multiple categories on create; optional for now to support existing data
-  categoryIds: z.array(z.number().int()).optional(),
-  // Also allow a single categoryId for convenience (accept number or array)
-  categoryId: z.union([z.number().int(), z.array(z.number().int())]).optional(),
-});
+const markupPercentageSchema = z
+  .number()
+  .positive('Markup percentage must be greater than 0');
+
+export const addProductSchema = z
+  .object({
+    name: z.string(),
+    description: z.string(),
+    stl: z.string(),
+    price: markupPercentageSchema
+      .optional()
+      .describe('Deprecated alias for markupPercentage.'),
+    markupPercentage: markupPercentageSchema
+      .optional()
+      .describe('Percentage markup to apply to the Slant3D estimated cost.'),
+    filamentType: z.string(),
+    color: z.string(),
+    image: z.string(),
+    imageGallery: z.array(z.string()).min(1).optional(),
+    // Accept multiple categories on create; optional for now to support existing data
+    categoryIds: z.array(z.number().int()).optional(),
+    // Also allow a single categoryId for convenience (accept number or array)
+    categoryId: z.union([z.number().int(), z.array(z.number().int())]).optional(),
+  })
+  .refine(data => data.price !== undefined || data.markupPercentage !== undefined, {
+    message: 'Either price or markupPercentage is required',
+    path: ['markupPercentage'],
+  });
 
 export const updateProductSchema = z.object({
   id: z.number(),
@@ -441,7 +455,7 @@ export const addCartItemSchema = z.object({
   quantity: z.number().int().min(1).max(69),
   color: z.string(),
   filamentType: z.string(),
-  filamentId: z.string().uuid().optional(),
+  filamentId: z.string().uuid(),
 });
 
 // Table for storing uploaded STL files with estimates from Slant3D

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -413,7 +413,19 @@ const product = factory
       const user = c.get('jwtPayload') as { id: string; email: string } | undefined;
       if (!user) return c.json({ error: 'Unauthorized' }, 401);
       const data = await c.req.valid('json');
-      const { categoryIds, categoryId, imageGallery, ...rest } = data;
+      const {
+        categoryIds,
+        categoryId,
+        imageGallery,
+        price: legacyMarkupPercentage,
+        markupPercentage,
+        ...productFields
+      } = data;
+      const requestedMarkupPercentage =
+        markupPercentage ?? legacyMarkupPercentage;
+      if (requestedMarkupPercentage === undefined) {
+        return c.json({ error: 'Markup percentage is required' }, 400);
+      }
       // Normalize category inputs: accept categoryIds array, categoryId number, or categoryId array
       let normalizedCategoryIds: number[] | undefined;
       if (Array.isArray(categoryIds)) {
@@ -470,7 +482,10 @@ const product = factory
       };
       console.log('slicing result', slicingResult);
       const basePrice = slicingResult.data.price;
-      const markupPrice = calculateMarkupPrice(basePrice, data.price);
+      const markupPrice = calculateMarkupPrice(
+        basePrice,
+        requestedMarkupPercentage,
+      );
 
       let stripePriceId = null;
       if (markupPrice) {
@@ -490,7 +505,7 @@ const product = factory
           : null;
 
       const productDataToInsert = {
-        ...rest,
+        ...productFields,
         price: markupPrice,
         skuNumber: skuNumber,
         stripeProductId: stripeProduct.id,
@@ -611,7 +626,19 @@ const product = factory
         if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
         const data = await c.req.valid('json');
-        const { categoryIds, categoryId, imageGallery, ...rest } = data;
+        const {
+          categoryIds,
+          categoryId,
+          imageGallery,
+          price: legacyMarkupPercentage,
+          markupPercentage,
+          ...productFields
+        } = data;
+        const requestedMarkupPercentage =
+          markupPercentage ?? legacyMarkupPercentage;
+        if (requestedMarkupPercentage === undefined) {
+          return c.json({ error: 'Markup percentage is required' }, 400);
+        }
         let normalizedCategoryIds: number[] | undefined;
         if (Array.isArray(categoryIds)) {
           normalizedCategoryIds = categoryIds;
@@ -851,7 +878,7 @@ const product = factory
           : undefined;
 
         console.log('Slant3D estimated base price:', basePrice);
-        console.log('Markup percentage from request:', data.price);
+        console.log('Markup percentage from request:', requestedMarkupPercentage);
 
         if (!basePrice || basePrice <= 0) {
           return c.json(
@@ -865,7 +892,10 @@ const product = factory
 
         let markupPrice: number;
         try {
-          markupPrice = calculateMarkupPrice(basePrice, data.price);
+          markupPrice = calculateMarkupPrice(
+            basePrice,
+            requestedMarkupPercentage,
+          );
         } catch (err: unknown) {
           console.error(
             'Error calculating markup price:',
@@ -900,7 +930,7 @@ const product = factory
             : null;
 
         const productDataToInsert = {
-          ...rest,
+          ...productFields,
           price: markupPrice,
           skuNumber: skuNumber,
           stripeProductId: stripeProduct.id,

--- a/src/routes/shoppingCart.ts
+++ b/src/routes/shoppingCart.ts
@@ -1,9 +1,9 @@
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, isNull, or } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { describeRoute } from 'hono-openapi';
 import Stripe from 'stripe';
 import { z } from 'zod';
-import { BASE_URL, BASE_URL_V2  } from '../constants';
+import { BASE_URL_V2 } from '../constants';
 import {
   addCartItemSchema,
   cart,
@@ -12,11 +12,11 @@ import {
   users,
 } from '../db/schema';
 import factory from '../factory';
-import { authMiddleware, optionalAuthMiddleware } from '../utils/authMiddleware';
-import { generateOrderNumber } from '../utils/generateOrderNumber';
 import {
-  decryptStoredShippingProfile,
-} from '../utils/profileCrypto';
+  authMiddleware,
+  optionalAuthMiddleware,
+} from '../utils/authMiddleware';
+import { decryptStoredShippingProfile } from '../utils/profileCrypto';
 
 // Schema for update cart item
 const updateCartItemSchema = z.object({
@@ -60,7 +60,9 @@ const createCheckoutSchema = z.object({
 const DEFAULT_BLACK_FILAMENT_ID = '76fe1f79-3f1e-43e4-b8f4-61159de5b93c';
 
 /** Extracts the authenticated caller's user ID from Hono context, if present. */
-function getCallerUserId(c: { get: (key: string) => unknown }): string | undefined {
+function getCallerUserId(c: {
+  get: (key: string) => unknown;
+}): string | undefined {
   const payload = c.get('jwtPayload') as { id?: string } | undefined;
   return payload?.id ?? undefined;
 }
@@ -136,14 +138,8 @@ const shoppingCart = factory
           state,
           zipCode,
           country,
-          phone: decryptedPhone,
         } = await decryptStoredShippingProfile(userRow, passphrase);
         const decryptMs = performance.now() - decryptStart;
-        let phone = decryptedPhone;
-        // Sanitize phone - keep digits and leading +, enforce <=20 chars
-        phone = phone ? phone.replace(/[^+0-9]/g, '') : '';
-        if (phone.length > 20) phone = phone.slice(0, 20);
-        if (!phone) phone = '0000000000'; // fallback minimal placeholder if upstream requires
 
         // Pull cart contents and join products to enrich data.
         const cartQueryStart = performance.now();
@@ -155,6 +151,7 @@ const shoppingCart = factory
             quantity: cart.quantity,
             color: cart.color,
             filamentType: cart.filamentType,
+            filamentId: cart.filamentId,
             productName: productsTable.name,
             publicFileServiceId: productsTable.publicFileServiceId,
           })
@@ -171,7 +168,10 @@ const shoppingCart = factory
 
         // Enforce cart ownership: reject if the cart is owned by a different user.
         // Use != null (loose) to treat both null and undefined as "no owner".
-        if (cartItems[0].cartUserId != null && cartItems[0].cartUserId !== userId) {
+        if (
+          cartItems[0].cartUserId != null &&
+          cartItems[0].cartUserId !== userId
+        ) {
           return c.json({ error: 'Forbidden' }, 403);
         }
 
@@ -258,31 +258,36 @@ const shoppingCart = factory
         };
 
         const payloadBuildStart = performance.now();
+        if (!c.env.SLANT_PLATFORM_ID) {
+          return c.json(
+            { error: 'Missing SLANT_PLATFORM_ID environment variable.' },
+            500,
+          );
+        }
         const countryCode = normalizeCountryCode(country);
         const recipientName = `${firstName} ${lastName}`.trim() || email;
         const address = {
           name: recipientName,
-          street1: shippingAddress,
-          street2: '',
-          street3: '',
+          line1: shippingAddress,
+          line2: '',
           city,
           state,
-          zipCode,
+          zip: zipCode,
           country: countryCode,
-          isResidential: true,
         };
         const draftOrderPayload = {
-          orderNumber: generateOrderNumber(),
+          platformId: c.env.SLANT_PLATFORM_ID,
+          ownerId: userId,
           customer: {
-            email,
-            phone,
-            name: recipientName,
+            details: {
+              email,
+              address,
+            },
           },
-          billingAddress: address,
-          shippingAddress: address,
-          orderItems: printableCartItems.map(cartItem => {
+          items: printableCartItems.map(cartItem => {
             const filamentId =
-              typeof cartItem.filamentId === 'string' && cartItem.filamentId.trim()
+              typeof cartItem.filamentId === 'string' &&
+              cartItem.filamentId.trim()
                 ? cartItem.filamentId
                 : DEFAULT_BLACK_FILAMENT_ID;
             const normalizedColor = normalizeColor(cartItem.color);
@@ -293,13 +298,10 @@ const shoppingCart = factory
               });
             }
             return {
+              type: 'PRINT',
               publicFileServiceId: cartItem.publicFileServiceId,
               filamentId,
               quantity: cartItem.quantity,
-              orderItemName: cartItem.productName,
-              orderSku: cartItem.skuNumber,
-              orderItemColor: normalizedColor,
-              profile: cartItem.filamentType,
             };
           }),
         };
@@ -307,14 +309,36 @@ const shoppingCart = factory
 
         // Draft and estimate the order with Slant3D V2.
         const upstreamStart = performance.now();
-        const response = await fetch(`${BASE_URL_V2}orders`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer '.concat(c.env.SLANT_API_V2),
-          },
-          body: JSON.stringify(draftOrderPayload),
+        const upstreamUrl = `${BASE_URL_V2}orders`;
+        const upstreamHost = new URL(upstreamUrl).host;
+        console.log('cart/shipping upstream request', {
+          url: upstreamUrl,
+          host: upstreamHost,
+          hasSlantApiV2: Boolean(c.env.SLANT_API_V2),
+          cartId,
+          userId,
+          ...summarizeDraftOrderPayload(draftOrderPayload),
         });
+
+        let response: Response;
+        try {
+          response = await fetch(upstreamUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer '.concat(c.env.SLANT_API_V2),
+            },
+            body: JSON.stringify(draftOrderPayload),
+          });
+        } catch (error) {
+          console.error('cart/shipping upstream fetch failed before response', {
+            url: upstreamUrl,
+            host: upstreamHost,
+            upstreamMs: Number((performance.now() - upstreamStart).toFixed(2)),
+            error: serializeError(error),
+          });
+          throw error;
+        }
         const upstreamMs = performance.now() - upstreamStart;
 
         const totalMs = Number((performance.now() - requestStart).toFixed(2));
@@ -328,8 +352,11 @@ const shoppingCart = factory
         };
 
         // Gate timing log on hot path to reduce overhead/log volume.
-        const sampleEnv = (c.env as any)?.CART_SHIPPING_TIMING_SAMPLE_RATE;
-        const sampleRate = typeof sampleEnv === 'string' ? Number(sampleEnv) : NaN;
+        const sampleEnv = (
+          c.env as { CART_SHIPPING_TIMING_SAMPLE_RATE?: unknown }
+        ).CART_SHIPPING_TIMING_SAMPLE_RATE;
+        const sampleRate =
+          typeof sampleEnv === 'string' ? Number(sampleEnv) : NaN;
         const isValidSampleRate =
           Number.isFinite(sampleRate) && sampleRate > 0 && sampleRate <= 1;
 
@@ -346,6 +373,11 @@ const shoppingCart = factory
           console.error(
             'Upstream draft order estimate error:',
             response.status,
+            {
+              url: upstreamUrl,
+              host: upstreamHost,
+              timings,
+            },
             errorDetails,
           );
           return c.json(
@@ -362,9 +394,19 @@ const shoppingCart = factory
         const shippingCost = extractShippingCost(data);
 
         if (shippingCost === undefined) {
+          console.error(
+            'cart/shipping upstream response missing shipping cost',
+            {
+              url: upstreamUrl,
+              host: upstreamHost,
+              timings,
+              response: data,
+            },
+          );
           return c.json(
             {
-              error: 'Upstream draft order estimate response missing shipping cost',
+              error:
+                'Upstream draft order estimate response missing shipping cost',
             },
             502,
           );
@@ -538,17 +580,17 @@ const shoppingCart = factory
     async c => {
       const { cartId, skuNumber, quantity, color, filamentType, filamentId } =
         c.req.valid('json');
+      console.log('POST /cart/add called with', {
+        cartId,
+        skuNumber,
+        quantity,
+        color,
+        filamentType,
+        filamentId,
+      });
 
       // Bind the cart item to the authenticated user when a session is present.
       const userId: string | null = getCallerUserId(c) ?? null;
-      const effectiveFilamentId = filamentId ?? DEFAULT_PLA_BLACK_FILAMENT_ID;
-      const filamentMatchCondition =
-        effectiveFilamentId === DEFAULT_PLA_BLACK_FILAMENT_ID
-          ? or(
-              eq(cart.filamentId, effectiveFilamentId),
-              isNull(cart.filamentId),
-            )
-          : eq(cart.filamentId, effectiveFilamentId);
 
       try {
         const existing = await c.var.db.query.cart.findFirst({
@@ -557,21 +599,25 @@ const shoppingCart = factory
             eq(cart.skuNumber, skuNumber),
             eq(cart.color, color),
             eq(cart.filamentType, filamentType),
-            filamentMatchCondition,
+            eq(cart.filamentId, filamentId),
           ),
         });
 
         if (existing) {
           // Enforce ownership: if the existing item has an owner, it must match the caller.
           // Use != null (loose) to treat both null and undefined as "no owner".
-          if (existing.userId != null && userId !== null && existing.userId !== userId) {
+          if (
+            existing.userId != null &&
+            userId !== null &&
+            existing.userId !== userId
+          ) {
             return c.json({ error: 'Forbidden' }, 403);
           }
           await c.var.db
             .update(cart)
             .set({
               quantity: existing.quantity + quantity,
-              filamentId: existing.filamentId ?? effectiveFilamentId,
+              filamentId,
             })
             .where(eq(cart.id, existing.id));
         } else {
@@ -582,12 +628,13 @@ const shoppingCart = factory
             quantity,
             color,
             filamentType,
-            filamentId: effectiveFilamentId,
+            filamentId,
           });
         }
 
         return c.json({ message: 'Item added to cart successfully' });
-      } catch (_error) {
+      } catch (error) {
+        console.error('POST /cart/add failed:', error);
         return c.json({ error: 'Failed to add item to cart' }, 500);
       }
     },
@@ -875,11 +922,17 @@ const shoppingCart = factory
     zValidator('json', createCheckoutSchema),
     async c => {
       const cartId = c.req.param('cartId');
-      const { successUrl, cancelUrl, customerEmail: bodyEmail, shippingAddress } =
-        c.req.valid('json');
+      const {
+        successUrl,
+        cancelUrl,
+        customerEmail: bodyEmail,
+        shippingAddress,
+      } = c.req.valid('json');
 
       // Extract userId and customerEmail from the authenticated session
-      const jwtPayload = c.get('jwtPayload') as { id?: string; email?: string } | undefined;
+      const jwtPayload = c.get('jwtPayload') as
+        | { id?: string; email?: string }
+        | undefined;
       const userId = jwtPayload?.id ? String(jwtPayload.id) : undefined;
       const customerEmail = bodyEmail ?? jwtPayload?.email;
 
@@ -1034,7 +1087,9 @@ const shoppingCart = factory
       if (!userId) {
         return c.json({ error: 'Unauthorized' }, 401);
       }
-      const jwtPayload = c.get('jwtPayload') as { id?: string; email?: string } | undefined;
+      const jwtPayload = c.get('jwtPayload') as
+        | { id?: string; email?: string }
+        | undefined;
       if (!customerEmail) {
         customerEmail = jwtPayload?.email;
       }
@@ -1153,9 +1208,9 @@ interface CartShippingItem {
   publicFileServiceId?: string | null;
 }
 
-function hasPublicFileServiceId<T extends { publicFileServiceId?: string | null }>(
-  item: T,
-): item is T & { publicFileServiceId: string } {
+function hasPublicFileServiceId<
+  T extends { publicFileServiceId?: string | null },
+>(item: T): item is T & { publicFileServiceId: string } {
   return (
     typeof item.publicFileServiceId === 'string' &&
     item.publicFileServiceId.trim().length > 0
@@ -1164,7 +1219,9 @@ function hasPublicFileServiceId<T extends { publicFileServiceId?: string | null 
 
 function normalizeCountryCode(country: string | null | undefined): string {
   const trimmed = country?.trim();
-  return trimmed && /^[A-Za-z]{2}$/.test(trimmed) ? trimmed.toUpperCase() : 'US';
+  return trimmed && /^[A-Za-z]{2}$/.test(trimmed)
+    ? trimmed.toUpperCase()
+    : 'US';
 }
 
 function extractShippingCost(response: DraftOrderResponse): number | undefined {
@@ -1174,15 +1231,18 @@ function extractShippingCost(response: DraftOrderResponse): number | undefined {
     ['shippingCost'],
     ['shipping_cost'],
     ['estimatedShippingCost'],
+    ['deliveryCost'],
     ['data', 'shippingCost'],
     ['data', 'shipping_cost'],
     ['data', 'estimatedShippingCost'],
+    ['data', 'deliveryCost'],
     ['data', 'shipping', 'shippingCost'],
     ['data', 'shipping', 'shipping_cost'],
     ['data', 'estimate', 'shippingCost'],
     ['data', 'estimate', 'shipping_cost'],
     ['data', 'estimatedCosts', 'shippingCost'],
     ['data', 'estimatedCosts', 'shipping_cost'],
+    ['data', 'order', 'deliveryCost'],
   ];
 
   for (const path of candidates) {
@@ -1223,7 +1283,72 @@ function toFiniteNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function parseUpstreamErrorDetails(errorText: string): string | Record<string, unknown> {
+function summarizeDraftOrderPayload(payload: {
+  platformId: string;
+  ownerId: string;
+  customer: {
+    details: {
+      email: string;
+      address: {
+        line1: string;
+        city: string;
+        state: string;
+        zip: string;
+        country: string;
+      };
+    };
+  };
+  items: Array<{
+    type: string;
+    publicFileServiceId: string;
+    filamentId: string;
+    quantity: number;
+  }>;
+}) {
+  return {
+    platformId: payload.platformId,
+    ownerId: payload.ownerId,
+    customer: {
+      hasEmail: payload.customer.details.email.length > 0,
+    },
+    shippingAddress: {
+      hasLine1: payload.customer.details.address.line1.length > 0,
+      cityPresent: payload.customer.details.address.city.length > 0,
+      state: payload.customer.details.address.state,
+      zip: payload.customer.details.address.zip,
+      country: payload.customer.details.address.country,
+    },
+    itemCount: payload.items.length,
+    items: payload.items.map(item => ({
+      type: item.type,
+      publicFileServiceId: item.publicFileServiceId,
+      filamentId: item.filamentId,
+      quantity: item.quantity,
+    })),
+  };
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const errorRecord = error as Error & {
+      cause?: unknown;
+      remote?: unknown;
+    };
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+      cause: errorRecord.cause,
+      remote: errorRecord.remote,
+    };
+  }
+
+  return { value: String(error) };
+}
+
+function parseUpstreamErrorDetails(
+  errorText: string,
+): string | Record<string, unknown> {
   if (!errorText) {
     return '';
   }

--- a/test/routes/product.spec.ts
+++ b/test/routes/product.spec.ts
@@ -290,8 +290,10 @@ describe('Product Routes', () => {
     // Inserted product should have null categoryId during transition
     const [productInsertOnly] = capturedInserts as Array<{
       categoryId: number | null;
+      price: number;
     }>;
     expect(productInsertOnly).toHaveProperty('categoryId', null);
+    expect(productInsertOnly.price).toBe(11.5);
   });
 
   test('POST /add-product handles slicer API failure', async () => {
@@ -370,10 +372,11 @@ describe('Product Routes', () => {
     // First insert is product; second insert is batch insert of join rows
     expect(capturedInserts.length).toBe(2);
     const [productInsert, batchJoinInsert] = capturedInserts as unknown as [
-      { id?: number; categoryId: number | null },
+      { id?: number; categoryId: number | null; price: number },
       Array<{ productId: number; categoryId: number; orderIndex: number }>,
     ];
     expect(productInsert).toMatchObject({ categoryId: 2 });
+    expect(productInsert.price).toBe(15);
     // Batch insert should contain all three category joins
     expect(Array.isArray(batchJoinInsert)).toBe(true);
     expect(batchJoinInsert.length).toBe(3);
@@ -570,7 +573,7 @@ describe('Product Routes', () => {
         name: 'V2 Product',
         description: 'desc',
         stl: 'https://uploads.example.com/test-file.stl',
-        price: 15,
+        markupPercentage: 15,
         image: 'url/to/image.jpg',
         filamentType: 'PLA',
         color: '#ffffff',
@@ -588,6 +591,9 @@ describe('Product Routes', () => {
     expect(data.product).toMatchObject({
       id: 7,
       publicFileServiceId: 'file_123',
+    });
+    expect(capturedInserts[0]).toMatchObject({
+      price: 11.5,
     });
   });
 

--- a/test/routes/shoppingCart.spec.ts
+++ b/test/routes/shoppingCart.spec.ts
@@ -250,9 +250,7 @@ describe('Shopping Cart Routes', () => {
       });
     });
 
-    test('defaults filamentId to PLA Black when omitted', async () => {
-      mockQuery.cart.findFirst.mockResolvedValueOnce(undefined);
-
+    test('returns validation error when filamentId is omitted', async () => {
       const request = new Request('http://localhost/cart/add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -267,12 +265,8 @@ describe('Shopping Cart Routes', () => {
 
       const res = await app.fetch(request, env);
 
-      expect(res.status).toBe(200);
-      expect(capturedInserts).toHaveLength(1);
-      expect(capturedInserts[0]).toMatchObject({
-        cartId: mockCartId,
-        filamentId: defaultBlackFilamentId,
-      });
+      expect(res.status).toBe(400);
+      expect(capturedInserts).toHaveLength(0);
     });
   });
 
@@ -355,8 +349,8 @@ describe('Shopping Cart Routes', () => {
     test('returns shipping estimate successfully', async () => {
       const mockDraftOrderResponse = {
         data: {
-          estimatedCosts: {
-            shippingCost: 15.99,
+          order: {
+            deliveryCost: '15.99',
           },
         },
       };
@@ -417,27 +411,37 @@ describe('Shopping Cart Routes', () => {
           method: 'POST',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            Authorization: 'Bearer ' + env.SLANT_API_V2,
+            Authorization: `Bearer ${env.SLANT_API_V2}`,
           }),
         }),
       );
 
       const fetchCall = (global.fetch as any).mock.calls[0];
       const requestBody = JSON.parse(fetchCall[1].body);
-      expect(requestBody.orderItems).toEqual([
+      expect(requestBody).toMatchObject({
+        platformId: env.SLANT_PLATFORM_ID,
+        ownerId: 'user_123',
+        customer: {
+          details: {
+            email: 'test@example.com',
+            address: {
+              line1: 'encrypted-123-main-st',
+              city: 'encrypted-testville',
+              state: 'encrypted-ts',
+              zip: 'encrypted-12345',
+              country: 'US',
+            },
+          },
+        },
+      });
+      expect(requestBody.items).toEqual([
         expect.objectContaining({
+          type: 'PRINT',
           publicFileServiceId: 'public-file-123',
           filamentId: '76fe1f79-3f1e-43e4-b8f4-61159de5b93c',
           quantity: 2,
-          orderSku: 'TEST-SKU-001',
         }),
       ]);
-      expect(requestBody.shippingAddress).toMatchObject({
-        city: 'encrypted-testville',
-        state: 'encrypted-ts',
-        zipCode: 'encrypted-12345',
-        country: 'US',
-      });
     });
 
     test('returns 400 when cartId is missing', async () => {
@@ -734,7 +738,12 @@ describe('Shopping Cart Routes', () => {
     test('returns 403 when cart is owned by a different authenticated user', async () => {
       // findMany returns items owned by a different user
       mockQuery.cart.findMany.mockResolvedValueOnce([
-        { id: 1, cartId: mockCartId, userId: 'different_user_456', quantity: 2 },
+        {
+          id: 1,
+          cartId: mockCartId,
+          userId: 'different_user_456',
+          quantity: 2,
+        },
       ]);
 
       const request = new Request('http://localhost/cart/update', {
@@ -888,9 +897,7 @@ describe('Shopping Cart Routes', () => {
     });
 
     test('returns 404 when no items with Stripe price IDs found', async () => {
-      mockWhere.mockResolvedValueOnce([
-        { stripePriceId: null, quantity: 1 },
-      ]);
+      mockWhere.mockResolvedValueOnce([{ stripePriceId: null, quantity: 1 }]);
 
       const res = await app.fetch(
         new Request(`http://localhost/cart/${mockCartId}/checkout`, {


### PR DESCRIPTION
## Project notes summary

- Moves the cart shipping estimate flow onto the Slant3D V2 order payload and response shapes.
- Updates product creation to use explicit `markupPercentage` semantics while keeping `price` as a legacy alias.
- Tightens cart item validation so `filamentId` must be supplied instead of being silently defaulted.
- Adds repo scripts and docs for the preferred D1 migration workflow: generate with Drizzle, apply remotely with `wrangler d1 migrations apply ecommerce --remote`.

## User-visible or operational impact

- `GET /cart/shipping` now sends the V2 draft-order shape with `platformId`, `ownerId`, nested `customer.details`, and `items`, and it parses shipping cost from the newer `deliveryCost`-style response.
- `POST /add-product` and `POST /v2/add-product` now compute the stored product price from the slicer estimate plus `markupPercentage`, with legacy `price` still accepted as the old field name.
- `POST /cart/add` now rejects requests that omit `filamentId` instead of defaulting it automatically.
- Product and cart tests were updated to cover the new request/response contracts.
- Maintainers now have `db:generate`, `db:migrate:local`, `db:push:local`, and `db:migrate:remote` scripts for the local and remote D1 migration workflow.

## Notes / lessons / caveats

- This branch includes regenerated Drizzle artifacts (`drizzle/migrations/schema.ts`, `relations.ts`, snapshot metadata, and `0004_ancient_triathlon.sql`) alongside the route changes.
- Review the generated migration carefully before merge: `0004_ancient_triathlon.sql` re-adds `cart.user_id` and `cart.filament_id`, which were already present in the remote database and required migration-state reconciliation.
- `drizzle.config.ts` currently contains a machine-specific local Wrangler/Miniflare SQLite path and should be normalized before merge if we want the branch to stay portable for other developers and CI.

- [ ] Skip project notes
